### PR TITLE
workPromise supports lazy evaluation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -94,8 +94,12 @@ PacedWorkStream.prototype._toPromises = function(items) {
   return promises;
 }
 PacedWorkStream.prototype._process = function(promises, cb) {
+  const doPromises = promises.map((pr) => {
+    return (typeof pr.then === 'function') ? pr : pr();
+  });
+
   const startTime = new Date().getTime();
-  Promise.all(promises)
+  Promise.all(doPromises)
   .then((results) => {
     results.forEach((result) => { this.push(result) });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paced-work-stream",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Node.js stream working at constant pace and concurrent",
   "main": "lib/main.js",
   "scripts": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -31,6 +31,33 @@ describe('PacedWorkStream', () => {
       reader.pipe(pwStream);
     });
 
+    it('raises done event with workPromise returns a function to return Promise', (done) => {
+      const pwStream = new PacedWorkStream({
+          concurrency: 2,
+          workMS: 0
+        }, function(item) {
+          const self = this;
+          return function() {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  self.countTag('workDone');
+                  resolve(item);
+                }, 20);
+              })
+          };
+        })
+        .on('done', function() {
+          assert.deepEqual(this.tagCounts, { workDone: 5 });
+          done();
+        }).on('error', (err) => {
+          assert.ifError(err);
+          done();
+        });
+
+      const reader = es.readArray([11, 12, 21, 22, 31])
+      reader.pipe(pwStream);
+    });
+
     it('raises done event with fraction', (done) => {
       const pwStream = new PacedWorkStream({
           concurrency: 2,


### PR DESCRIPTION
`workPromise` can also returns a function to return creating a Promise.
It is able to delay doing the Promise until concurrent processes start.
